### PR TITLE
Added link to regressionf Found=<Major Version> of Chromium

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Show Chrome Version",
   "short_name": "ShowChromeVersion",
   "description": "Show Chrome version info",
-  "version": "0.0.3.1",
+  "version": "0.0.3.2",
   "author": "Eric Lawrence (@ericlaw)",
 
   "minimum_chrome_version": "48",

--- a/popup.css
+++ b/popup.css
@@ -6,5 +6,5 @@ a:hover { text-decoration: underline }
 a:focus { text-decoration: underline; border: none; }
 ::selection { background:#C6FFDE; }
 
-#divFooter { width:100%; margin-top:20px; text-align:right; -webkit-user-select: none;}
-#lnkAllVersions, #lnkCopyForBug, #lnkSysInfo, #lnkMoreInfo { color: blue; font-size: xx-small; text-align: right; cursor: pointer; margin-right: 10px; }
+#divFooter { margin-top:20px; -webkit-user-select: none; display: flex;}
+#lnkAllVersions, #lnkCopyForBug, #lnkSysInfo, #lnkMoreInfo, #lnkRegressionsForThisVersion { color: blue; padding: 5px; font-size: xx-small; text-align: right; cursor: pointer; }

--- a/popup.html
+++ b/popup.html
@@ -10,9 +10,11 @@
     <h1 id="txtTitle">Chrome Version</h1>
     <div style="text-align: center; font-family: monospace; font-size: large; margin-top: 10px;" id="txtStatus">Loading version info...</div>
     <div id="divFooter">
-                        <span id="lnkCopyForBug">Copy</span>
-                        <span id="lnkMoreInfo">Full Chrome Info</span>
-                        <span id="lnkSysInfo">System Info</span>
-                        <span id="lnkAllVersions">All Versions</a></span></div>
+        <span id="lnkCopyForBug">Copy</span>
+        <span id="lnkMoreInfo">Full Chrome Info</span>
+        <span id="lnkSysInfo">System Info</span>
+        <span id="lnkAllVersions">All Versions</a></span>
+        <span id="lnkRegressionsForThisVersion">View Regressions</span>
+    </div>
   </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -2,16 +2,7 @@
 
 if (typeof chrome.runtime === "undefined") chrome = browser;
 
-document.addEventListener('DOMContentLoaded', function() {
-        chrome.runtime.getPlatformInfo(function (o) {
-            const arrVer = / Edg\/([0-9.]+)/.exec(navigator.userAgent);
-            let sEdge = (arrVer && arrVer.length > 0) ? arrVer[1] : "";
-            if (sEdge) (sEdge = "Edge v" + sEdge + "; Chromium v");
-            document.getElementById("txtStatus").textContent = sEdge +
-            /Chrome\/([0-9.]+)/.exec(navigator.userAgent)[1] + "\n" +
-            JSON.stringify(o);
-        });
-
+document.addEventListener('DOMContentLoaded', function() {        
         const lnkMoreInfo = document.getElementById("lnkMoreInfo");
         lnkMoreInfo.addEventListener("click", function() { chrome.tabs.create({url: "chrome://version/?show-variations-cmd"}); }, false);
 
@@ -22,16 +13,28 @@ document.addEventListener('DOMContentLoaded', function() {
         lnkSysInfo.addEventListener("click", function() { chrome.tabs.create({url: "chrome://system/"}); }, false);
 
         const lnkCopyForBug = document.getElementById("lnkCopyForBug");
-        lnkCopyForBug.addEventListener("click", function() { copyForBug(); }, false);
+        lnkCopyForBug.addEventListener("click", function() { copyForBug(); }, false);        
 
         if (navigator.userAgent.indexOf(" Edg/") > -1) {
           document.getElementById("txtTitle").textContent = "Edge Version";
           document.getElementById("lnkMoreInfo").textContent = "Full Edge Info";
         }
 
+        chrome.runtime.getPlatformInfo(function (o) {
+            const arrVer = / Edg\/([0-9.]+)/.exec(navigator.userAgent);
+            let sEdge = (arrVer && arrVer.length > 0) ? arrVer[1] : "";
+            if (sEdge) (sEdge = "Edge v" + sEdge + "; Chromium v");
+            let data = sEdge + /Chrome\/([0-9.]+)/.exec(navigator.userAgent)[1] + "\n" + JSON.stringify(o);
+            document.getElementById("txtStatus").textContent = data;
+
+            const majorVersion = arrVer[1].match(/(\d{1,3})/g)[0];
+            const lnlnkRegressionsForThisVersion = document.getElementById("lnkRegressionsForThisVersion");
+            let href = `https://bugs.chromium.org/p/chromium/issues/list?can=2&q=FoundIn%3D${majorVersion}+`;     
+            lnlnkRegressionsForThisVersion.addEventListener("click", function() { chrome.tabs.create({url: href });}, false);
+        });
 }, false);
 
-function copyForBug()
+function copyForBug() 
 {
     const copyFrom = document.createElement("textarea");
 
@@ -46,4 +49,3 @@ function copyForBug()
     lnkCopyForBug.textContent = "copied!";
     setTimeout(function() { lnkCopyForBug.innerHTML = "Copy"; }, 450);
 }
-


### PR DESCRIPTION
All this change ultimately does is add a link to query CR bug for known regressed issues in the current major version via the FoundIn label. I did have to move some code around in order to access the platform data.